### PR TITLE
fix(views): hide time created, and byline/access for site calendars

### DIFF
--- a/views/default/object/calendar.php
+++ b/views/default/object/calendar.php
@@ -55,12 +55,21 @@ if ($owner instanceof \ElggUser || $owner instanceof \ElggGroup) {
 
 if ($full) {
 	$content = elgg_view('events_ui/calendar', $vars);
-	echo elgg_view('object/elements/full', array(
+	$full_vars = [
 		'entity' => $entity,
 		'summary' => $summary,
+
+		// TODO does nothing: https://github.com/hypeJunction/hypeUI/issues/12
 		'icon' => $icon,
+
 		'body' => $content,
-	));
+		'time' => false,
+	];
+	if ($owner instanceof \ElggSite) {
+		$full_vars['access'] = false;
+		$full_vars['byline'] = false;
+	}
+	echo elgg_view('object/elements/full', $full_vars);
 } else {
 	echo elgg_view_image_block($icon, $summary);
 }


### PR DESCRIPTION
Fixes #9

Doesn't fix site icon (?) appearing for site calendar, but can be fixed other ways.